### PR TITLE
[Fix][Server]handling situations where jobexecution was not found

### DIFF
--- a/datavines-server/src/main/java/io/datavines/server/dqc/coordinator/runner/JobScheduler.java
+++ b/datavines-server/src/main/java/io/datavines/server/dqc/coordinator/runner/JobScheduler.java
@@ -82,6 +82,9 @@ public class JobScheduler extends Thread {
                             jobExecuteManager.addExecuteCommand(jobExecution);
                             jobExternalService.deleteCommandById(command.getId());
                             logger.info(String.format("submit success, jobExecution : %s", jobExecution.getName()) );
+                        } else {
+                            jobExternalService.deleteCommandById(command.getId());
+                            logger.info(String.format("jobexecution not found , command : %s", JSONUtils.toJsonString(command)));
                         }
                     } else if (CommandType.STOP == command.getType()) {
                         jobExecuteManager.addKillCommand(command.getJobExecutionId());


### PR DESCRIPTION
handling situations where jobexecution was not found, in order not to fall into a dead cycle 