### PR TITLE
[FIX][Common]Fix Hive sql query will skip first row

### DIFF
--- a/datavines-common/src/main/java/io/datavines/common/datasource/jdbc/utils/HiveSqlUtils.java
+++ b/datavines-common/src/main/java/io/datavines/common/datasource/jdbc/utils/HiveSqlUtils.java
@@ -46,32 +46,27 @@ public class HiveSqlUtils {
             jdbcTemplate.setMaxRows(Math.min(limit, DEFAULT_LIMIT));
         }
 
+        List<QueryColumn> queryColumns = new ArrayList<>();
+        List<Map<String, Object>> resultList = new ArrayList<>();
         jdbcTemplate.query(sql, rs -> {
-
             ResultSetMetaData metaData = rs.getMetaData();
-            List<QueryColumn> queryColumns = new ArrayList<>();
-            for (int i = 1; i <= metaData.getColumnCount(); i++) {
-                queryColumns.add(new QueryColumn(metaData.getColumnLabel(i), metaData.getColumnTypeName(i)));
-            }
-            listWithQueryColumn.setColumns(queryColumns);
-
-            List<Map<String, Object>> resultList = new ArrayList<>();
-
-            try {
-                while (rs.next()) {
-                    resultList.add(getResultObjectMap(rs, metaData));
+            if(CollectionUtils.isEmpty(queryColumns)){
+                for (int i = 1; i <= metaData.getColumnCount(); i++) {
+                    queryColumns.add(new QueryColumn(metaData.getColumnLabel(i), metaData.getColumnTypeName(i)));
                 }
+            }
+            try {
+                resultList.add(getResultObjectMap(rs, metaData));
             } catch (Throwable e) {
                 logger.error("get data error", e);
             }
-
-            listWithQueryColumn.setResultList(resultList);
-
-            logger.info("query for {} ms, total count:{} sql:{}",
-                    System.currentTimeMillis() - before,
-                    listWithQueryColumn.getResultList().size(),
-                    formatSql(sql));
         });
+        listWithQueryColumn.setColumns(queryColumns);
+        listWithQueryColumn.setResultList(resultList);
+        logger.info("query for {} ms, total count:{} sql:{}",
+                System.currentTimeMillis() - before,
+                listWithQueryColumn.getResultList().size(),
+                formatSql(sql));
 
         return listWithQueryColumn;
     }


### PR DESCRIPTION
对于 Hive 类型的数据源，在使用 SQL编辑器执行 SQL查询时会跳过第一条数据
可能是因为 HiveSqlUtils 中 
`jdbcTemplate.query(sql, rs -> {});`
这里 rs 是  `RowCallbackHandler` 不需要 `rs.next()` [not need call next()](https://github.com/spring-projects/spring-framework/blob/610de3ae786812f332b71a7453a67afd39834a03/spring-jdbc/src/main/java/org/springframework/jdbc/core/RowCallbackHandler.java#L50)


limit 1 跳过了第一条 显示无数据
![7cd7fd3b93568d6dd16879161bd80f1](https://github.com/datavane/datavines/assets/58384836/938493e1-4860-43e7-9226-2240782d4d6c)

limit 2 跳过了第一条 只显示一条数据
![dc2ddfba441a7b6ac73e683c74437b3](https://github.com/datavane/datavines/assets/58384836/e8d55472-6f33-4f37-b763-9a1c637d69e9)


