### PR TITLE
[Fix][Metric]Fix When the filter condition is an empty string, SQL concatenation may encounter syntax issues

### DIFF
--- a/datavines-metric/datavines-metric-plugins/datavines-metric-base/src/main/java/io/datavines/metric/plugin/base/BaseSingleTable.java
+++ b/datavines-metric/datavines-metric-plugins/datavines-metric-base/src/main/java/io/datavines/metric/plugin/base/BaseSingleTable.java
@@ -22,6 +22,7 @@ import io.datavines.common.entity.ExecuteSql;
 import io.datavines.metric.api.ConfigItem;
 import io.datavines.metric.api.MetricLevel;
 import io.datavines.metric.api.SqlMetric;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.*;
 
@@ -71,7 +72,8 @@ public abstract class BaseSingleTable implements SqlMetric {
 
     @Override
     public void prepare(Map<String, String> config) {
-        if (config.containsKey("filter")) {
+        // If the filter condition is an empty string, using String.join may result in SQL syntax errors.
+        if (config.containsKey("filter") && StringUtils.isNotBlank(config.get("filter"))) {
             filters.add(config.get("filter"));
         }
 


### PR DESCRIPTION
在某些情况下添加作业的时候, 对于这个过滤条件虽然没有填 (比如先填写 再清空)
![1694703063182](https://github.com/datavane/datavines/assets/58384836/28a530ce-45f5-49c5-849d-46b97b7ff531)
 
会在 `dv_job.parameter` 表中，存入 fliter 这个属性。
![image](https://github.com/datavane/datavines/assets/58384836/afb8dee8-1a72-44b8-8aba-de0995f2c586)

这样在 拼接 SQL 时 `io.datavines.metric.plugin.base.BaseSingleTable`  的
```java
    private void addFiltersIntoInvalidateItemsSql() {
        if (filters.size() > 0) {
            invalidateItemsSql.append(" where ").append(String.join(" and ", filters));
        }
    }
```
就会 将 空字符串拼接进去，拼接出 类似 `select * from datavines.dv_actual_values where (unique_code is null ) and  ` 的 SQL






