### PR TITLE
[Fix][UI] Fix When editing a job, the database is empty and cannot be selected in the newly added tab

### DIFF
--- a/datavines-ui/Editor/components/MetricModal/MetricTabs.tsx
+++ b/datavines-ui/Editor/components/MetricModal/MetricTabs.tsx
@@ -171,9 +171,16 @@ const MetricTabs = (props: TmetricTabsProps) => {
                     // @ts-ignore
                     $name: values.name, uuid: guid(), ...detail, parameterItem: {},
                 };
-                if (detail?.parameterItem && !detail?.id) {
-                    // @ts-ignore
-                    item.parameterItem = { ...(detail?.parameterItem || {}) };
+                if (detail?.parameterItem) {
+                    if(!detail?.id){
+                        // @ts-ignore
+                        item.parameterItem = { ...(detail?.parameterItem || {}) };
+                    }else {
+                        // In editing interface, pass the detail.parameterItem.metricParameter into the item
+                        if(item && item.parameterItem){
+                            item.parameterItem.metricParameter = detail?.parameterItem?.metricParameter
+                        }
+                    }
                 }
                 newPanes.push(item);
                 setItems(newPanes);


### PR DESCRIPTION
When editing a job, the database is empty and cannot be selected in the newly added tab.
Because it uses this code to parse the database
```
const {
                database, table, column, filter, ...rest
            } = detail?.parameterItem?.metricParameter || {} as TMetricParameter;
```



