### PR TITLE
[Feature][Metric] Fix When the filter condition is an empty string, ColumnUnique,ColumnDuplicate and other plugin SQL concatenation may encounter syntax issues.

### DIFF
--- a/datavines-metric/datavines-metric-expected-plugins/datavines-metric-expected-table-rows/src/main/java/io/datavines/metric/expected/plugin/TableTotalRows.java
+++ b/datavines-metric/datavines-metric-expected-plugins/datavines-metric-expected-table-rows/src/main/java/io/datavines/metric/expected/plugin/TableTotalRows.java
@@ -17,6 +17,7 @@
 package io.datavines.metric.expected.plugin;
 
 import io.datavines.metric.api.ExpectedValue;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Map;
 
@@ -63,7 +64,7 @@ public class TableTotalRows implements ExpectedValue {
 
     @Override
     public void prepare(Map<String, String> config) {
-        if (config.containsKey("filter")) {
+        if (config.containsKey("filter") && StringUtils.isNotBlank(config.get("filter"))) {
             if (sql.toString().contains("where")) {
                 sql.append(" and ").append(config.get("filter"));
             } else {

--- a/datavines-metric/datavines-metric-expected-plugins/datavines-metric-expected-target-table-rows/src/main/java/io/datavines/metric/expected/plugin/TargetTableTotalRows.java
+++ b/datavines-metric/datavines-metric-expected-plugins/datavines-metric-expected-target-table-rows/src/main/java/io/datavines/metric/expected/plugin/TargetTableTotalRows.java
@@ -17,6 +17,7 @@
 package io.datavines.metric.expected.plugin;
 
 import io.datavines.metric.api.ExpectedValue;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Map;
 
@@ -63,7 +64,7 @@ public class TargetTableTotalRows implements ExpectedValue {
 
     @Override
     public void prepare(Map<String, String> config) {
-        if (config.containsKey("filter")) {
+        if (config.containsKey("filter") && StringUtils.isNotBlank(config.get("filter"))) {
             if (sql.toString().contains("where")) {
                 sql.append(" and ").append(config.get("filter"));
             } else {

--- a/datavines-metric/datavines-metric-plugins/datavines-metric-column-duplicate/src/main/java/io/datavines/metric/plugin/ColumnDuplicate.java
+++ b/datavines-metric/datavines-metric-plugins/datavines-metric-column-duplicate/src/main/java/io/datavines/metric/plugin/ColumnDuplicate.java
@@ -20,6 +20,7 @@ import io.datavines.common.enums.DataVinesDataType;
 import io.datavines.metric.api.MetricDimension;
 import io.datavines.metric.api.MetricType;
 import io.datavines.metric.plugin.base.BaseSingleTableColumn;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Arrays;
 import java.util.List;
@@ -61,7 +62,7 @@ public class ColumnDuplicate extends BaseSingleTableColumn {
     @Override
     public void prepare(Map<String, String> config) {
 
-        if (config.containsKey("filter")) {
+        if (config.containsKey("filter") && StringUtils.isNotBlank(config.get("filter"))) {
             invalidateItemsSql.append(" where ").append(config.get("filter"));
         }
 

--- a/datavines-metric/datavines-metric-plugins/datavines-metric-column-unique/src/main/java/io/datavines/metric/plugin/ColumnUnique.java
+++ b/datavines-metric/datavines-metric-plugins/datavines-metric-column-unique/src/main/java/io/datavines/metric/plugin/ColumnUnique.java
@@ -20,6 +20,7 @@ import io.datavines.common.enums.DataVinesDataType;
 import io.datavines.metric.api.MetricDimension;
 import io.datavines.metric.api.MetricType;
 import io.datavines.metric.plugin.base.BaseSingleTableColumn;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Arrays;
 import java.util.List;
@@ -61,7 +62,7 @@ public class ColumnUnique extends BaseSingleTableColumn {
     @Override
     public void prepare(Map<String, String> config) {
 
-        if (config.containsKey("filter")) {
+        if (config.containsKey("filter") && StringUtils.isNotBlank(config.get("filter"))) {
             invalidateItemsSql.append(" where ").append(config.get("filter"));
         }
 

--- a/datavines-metric/datavines-metric-plugins/datavines-metric-multi-table-accuracy/src/main/java/io/datavines/metric/plugin/MultiTableAccuracy.java
+++ b/datavines-metric/datavines-metric-plugins/datavines-metric-multi-table-accuracy/src/main/java/io/datavines/metric/plugin/MultiTableAccuracy.java
@@ -25,6 +25,7 @@ import io.datavines.metric.api.ConfigItem;
 import io.datavines.metric.api.MetricDimension;
 import io.datavines.metric.api.MetricType;
 import io.datavines.metric.api.SqlMetric;
+import org.apache.commons.lang3.StringUtils;
 
 import static io.datavines.common.ConfigConstants.METRIC_UNIQUE_KEY;
 
@@ -78,11 +79,11 @@ public class MultiTableAccuracy implements SqlMetric {
 
     @Override
     public void prepare(Map<String, String> config) {
-        if (config.containsKey("filter")) {
+        if (config.containsKey("filter") && StringUtils.isNotBlank(config.get("filter"))) {
             sourceTableSql.append(" WHERE (${filter}) ");
         }
 
-        if (config.containsKey("filter2")) {
+        if (config.containsKey("filter2") && StringUtils.isNotBlank(config.get("filter2"))) {
             targetTableSql.append(" WHERE (${filter2}) ");
         }
 


### PR DESCRIPTION
Fix When the filter condition is an empty string, some metric plugin SQL concatenation may encounter syntax issues.
- ColumnUnique
- ColumnDuplicate
- TableTotalRows
- TargetTableTotalRows
- MultiTableAccuracy