### PR TITLE
[Feature-332][UI] Add table comment fields to the table list in the data catalog interface

### DIFF
--- a/datavines-server/src/main/java/io/datavines/server/repository/service/impl/CatalogEntityInstanceServiceImpl.java
+++ b/datavines-server/src/main/java/io/datavines/server/repository/service/impl/CatalogEntityInstanceServiceImpl.java
@@ -169,7 +169,9 @@ public class CatalogEntityInstanceServiceImpl
             queryWrapper.lambda()
                     .in(CatalogEntityInstance::getUuid, uuidList)
                     .eq(CatalogEntityInstance::getStatus, CommonConstants.CATALOG_ENTITY_INSTANCE_STATUS_ACTIVE)
-                    .like(StringUtils.isNotEmpty(name), CatalogEntityInstance::getDisplayName, name)
+                    .and(qw ->  qw.like(StringUtils.isNotEmpty(name), CatalogEntityInstance::getDisplayName, name)
+                                    .or()
+                                    .like(StringUtils.isNotEmpty(name), CatalogEntityInstance::getDescription, name))
                     .orderBy(true, true, CatalogEntityInstance::getId);
             return page(page, queryWrapper);
         }
@@ -261,6 +263,7 @@ public class CatalogEntityInstanceServiceImpl
                 CatalogTableDetailVO table = new CatalogTableDetailVO();
                 table.setName(item.getDisplayName());
                 table.setUuid(item.getUuid());
+                table.setComment(item.getDescription());
                 table.setUpdateTime(item.getUpdateTime());
                 List<CatalogEntityInstance> columnList = getCatalogEntityInstances(item.getUuid());
                 table.setColumns((long)(CollectionUtils.isEmpty(columnList)? 0 : columnList.size()));

--- a/datavines-ui/Editor/components/Database/option.tsx
+++ b/datavines-ui/Editor/components/Database/option.tsx
@@ -35,6 +35,11 @@ export const dataBaseCol:Col[][] = [[{
     render: (_: any, { name }: any) => <span className="text-underline">{name}</span>,
 },
 {
+    title: <FormattedMessage id="job_comment" />,
+    dataIndex: 'comment',
+    key: 'comment',
+},
+{
     title: <FormattedMessage id="job_last_refresh_time" />,
     dataIndex: 'updateTime',
     key: 'updateTime',


### PR DESCRIPTION
#332 
- Add table comment fields to the table list in the data catalog interface
- Support table name and table comments search

![image](https://github.com/datavane/datavines/assets/58384836/2b8921ca-a9e9-4b39-a36d-a8e97f6f3fad)
