### PR TITLE
[Fix-350][Connector] Fix Hive getMetaTables and getMetadataColumns methods.

### DIFF
--- a/datavines-connector/datavines-connector-plugins/datavines-connector-hive/src/main/java/io/datavines/connector/plugin/HiveConnector.java
+++ b/datavines-connector/datavines-connector-plugins/datavines-connector-hive/src/main/java/io/datavines/connector/plugin/HiveConnector.java
@@ -36,6 +36,16 @@ public class HiveConnector extends JdbcConnector {
     }
 
     @Override
+    public ResultSet getMetadataColumns(DatabaseMetaData metaData, String catalog, String schema, String tableName, String columnName) throws SQLException {
+        return metaData.getColumns(null, catalog, tableName, columnName);
+    }
+
+    @Override
+    protected ResultSet getMetadataTables(DatabaseMetaData metaData, String catalog, String schema) throws SQLException {
+        return metaData.getTables(null, catalog, null, TABLE_TYPES);
+    }
+
+    @Override
     protected ResultSet getPrimaryKeys(DatabaseMetaData metaData, String catalog, String schema, String tableName) throws SQLException {
         return null;
     }


### PR DESCRIPTION
#350 
hive jdbc use
```java
metaData.getTables(null, 'database', null, TABLE_TYPES);
```
instead of 
```java
metaData.getTables('database', null, null, TABLE_TYPES);
```