### PR TITLE
[Fix][UI] Fixed version of @types/redux-logger

### DIFF
--- a/datavines-ui/package.json
+++ b/datavines-ui/package.json
@@ -51,7 +51,7 @@
     "@types/react-dom": "^18.0.9",
     "@types/react-redux": "^7.1.24",
     "@types/react-router-dom": "^5.2.0",
-    "@types/redux-logger": "^3.0.9",
+    "@types/redux-logger": "3.0.9",
     "@typescript-eslint/eslint-plugin": "^5.21.0",
     "@typescript-eslint/parser": "^5.21.0",
     "babel-loader": "^8.2.5",


### PR DESCRIPTION
#344
Fixed version of @types/redux-logger is 3.0.9

If packaging fails, check the version of  @types/redux-logger
```
cd datavines-ui
npm list redux
```
Observe if the version of @types/redux-logger  is 3.0.13,If it is 3.0.13, You can manually install version 3.0.9.
```
npm install --save  @types/redux-logger@3.0.9 --registry https://registry.npmmirror.com
```

Because @types/redux-logger@3.0.9 version 3.0.13 requires the redux version to be at least 5.0.0 
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/redux-logger/package.json

but this project requires a redux version of 4
