### PR TITLE
[Fix-372][Server,Metric] Fix datavines-submit.sh execute job configuration json error

### DIFF
--- a/datavines-metric/datavines-metric-api/src/main/java/io/datavines/metric/api/MetricValidator.java
+++ b/datavines-metric/datavines-metric-api/src/main/java/io/datavines/metric/api/MetricValidator.java
@@ -18,6 +18,7 @@ package io.datavines.metric.api;
 
 import io.datavines.common.enums.OperatorType;
 import io.datavines.spi.PluginLoader;
+import org.apache.commons.lang3.StringUtils;
 
 import java.math.BigDecimal;
 
@@ -34,7 +35,7 @@ public class MetricValidator {
         Double actualValue = executionResult.getActualValue();
         Double expectedValue = executionResult.getExpectedValue();
 
-        OperatorType operatorType = OperatorType.of(executionResult.getOperator());
+        OperatorType operatorType = OperatorType.of(StringUtils.trim(executionResult.getOperator()));
         ResultFormula resultFormula = PluginLoader.getPluginLoader(ResultFormula.class)
                 .getOrCreatePlugin(executionResult.getResultFormula());
 

--- a/datavines-server/src/main/java/io/datavines/server/utils/DefaultDataSourceInfoUtils.java
+++ b/datavines-server/src/main/java/io/datavines/server/utils/DefaultDataSourceInfoUtils.java
@@ -52,7 +52,12 @@ public class DefaultDataSourceInfoUtils {
         configMap.put(USER, connectionInfo.getUser());
         configMap.put(PASSWORD, connectionInfo.getPassword());
         configMap.put(DRIVER, connectionInfo.getDriverName());
-
+        configMap.put(HOST, connectionInfo.getHost());
+        configMap.put(PORT, connectionInfo.getPort());
+        configMap.put(CATALOG, connectionInfo.getCatalog());
+        configMap.put(DATABASE, connectionInfo.getDatabase());
+        configMap.put(SCHEMA, connectionInfo.getSchema());
+        configMap.put(PROPERTIES, connectionInfo.getProperties());
         return configMap;
     }
 }


### PR DESCRIPTION
close #372 
# 1. json copied directly from job error
Incomplete attributes in JSON leading to errors
```json
"validateResultDataStorageParameter": {
        "src_connector_type": "mysql",
        "password": "123456",
        "driver": "com.mysql.cj.jdbc.Driver",
        "user": "root",
        "url": "jdbc:mysql://127.0.0.1:3306/datavines?useUnicode=true&characterEncoding=UTF-8&useSSL=false&serverTimezone=Asia/Shanghai"
    }
```
Missing properties such as Host, port, database, etc

# 2. json for [reference documents](https://datavane.github.io/datavines-website/docs/user-guide/local-mode#%E6%B7%BB%E5%8A%A0%E4%BB%A5%E4%B8%8B%E5%86%85%E5%AE%B9%E5%88%B0%E9%85%8D%E7%BD%AE%E6%96%87%E4%BB%B6%E4%B8%AD)

```
OperatorType operatorType = OperatorType.of(executionResult.getOperator());
```
The operateType read out is " eq" instead of "eq", with an additional space



