### PR TITLE
[Fix-407][Connector] fix fetching metadata in case-sensitive databases

### DIFF
--- a/datavines-connector/datavines-connector-plugins/datavines-connector-jdbc/src/main/java/io/datavines/connector/plugin/JdbcConnector.java
+++ b/datavines-connector/datavines-connector-plugins/datavines-connector-jdbc/src/main/java/io/datavines/connector/plugin/JdbcConnector.java
@@ -243,7 +243,12 @@ public abstract class JdbcConnector implements Connector, IJdbcDataSourceInfo {
                 String name = rs.getString("COLUMN_NAME");
                 String rawType = rs.getString("TYPE_NAME");
                 String comment = rs.getString("REMARKS");
-                columnList.add(new ColumnInfo(name, rawType, comment,false));
+                String curTableName = rs.getString("TABLE_NAME");
+                // If the meta database is case-insensitive, it will identify fields that are not in the current table.
+                // e.g. When querying a table named test, both the test and TEST table fields will be queried simultaneously.
+                if(tableName.equals(curTableName)){
+                    columnList.add(new ColumnInfo(name, rawType, comment,false));
+                }
             }
         } catch (Exception e) {
             logger.error("get column error, param is {} :", schema + "." + tableName, e);

--- a/datavines-ui/src/view/Register/index.tsx
+++ b/datavines-ui/src/view/Register/index.tsx
@@ -75,7 +75,7 @@ const Index = () => {
                 rules: [
                     { required: true, message: `${phoneText}${requiredTop}` },
                 ],
-                widget: <Input autoComplete="off" placeholder={`${inputTip}${emailText}`} />,
+                widget: <Input autoComplete="off" placeholder={`${inputTip}${phoneText}`} />,
             },
             {
                 label: `${verificationCodeText}`,

--- a/scripts/sql/datavines-mysql-upgrade-0602.sql
+++ b/scripts/sql/datavines-mysql-upgrade-0602.sql
@@ -42,3 +42,6 @@ CREATE TABLE `dv_job_execution_result_report_rel` (
     UNIQUE KEY `dv_execution_report_rel_un` (`job_execution_result_id`,`quality_report_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='质量报告和执行结果关联关系';
 
+
+-- update  collate
+alter table dv_catalog_entity_instance modify fully_qualified_name varchar(255) collate utf8mb4_bin not null comment '全限定名';


### PR DESCRIPTION
<!--

Thank you for contributing to DataVines! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/datavines-ops/datavines/issues).

  - Name the pull request in the form "[DataVines #XXXX] [component] Title of the pull request", where *DataVines #XXXX* should be replaced by the actual issue number.

  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.

-->

## Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->
close #407 
- Fix inability to collect metadata for tables with the same name but different capitalization in case sensitive databases
Collete has been set for the `fully_qualified_name` field in the `dv_catalog_entity_instance` table to make it case-sensitive.
So we need to execute the following SQL statements
`alter table dv_catalog_entity_instance modify fully_qualified_name varchar(255) collate utf8mb4_bin not null comment '全限定名';`

- Check table name after fetching columns



## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] Change does not need document change
