### PR TITLE
[Improvement][Scripts] Change shell scripts to UNIX line-ending format when Maven build

### DIFF
--- a/datavines-dist/src/main/assembly/datavines-bin.xml
+++ b/datavines-dist/src/main/assembly/datavines-bin.xml
@@ -65,6 +65,7 @@
                 <include>datavines-submit.sh</include>
             </includes>
             <outputDirectory>./bin</outputDirectory>
+            <lineEnding>unix</lineEnding>
         </fileSet>
 
         <fileSet>


### PR DESCRIPTION
## Purpose of this pull request
Change shell scripts to UNIX line-ending format when Maven build, to avoid start failure after package deployment.
在Maven构建打包时将shell脚本更改为UNIX行尾格式，避免包部署后启动失败。


## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] Change does not need document change
