### PR TITLE
[Fix][Engine] Field type mismatch

### DIFF
--- a/datavines-engine/datavines-engine-config/src/main/java/io/datavines/engine/config/MetricParserUtils.java
+++ b/datavines-engine/datavines-engine-config/src/main/java/io/datavines/engine/config/MetricParserUtils.java
@@ -174,9 +174,9 @@ public class MetricParserUtils {
         for (int i = 0; i < mappingColumnList.size(); i++) {
             MappingColumn column = mappingColumnList.get(i);
             if (index == 1) {
-                columnList[i] = tableAlias + "." + QuoteIdentifier.quote(column.getColumn(), needQuote) + " AS " +  QuoteIdentifier.quote(column.getColumn() + "_" + index, needQuote);;
+                columnList[i] = tableAlias + "." + QuoteIdentifier.quote(column.getColumn(), needQuote) + " AS " +  QuoteIdentifier.quote(column.getColumn() + "_" + index, needQuote);
             } else if (index == 2){
-                columnList[i] = tableAlias + "." + QuoteIdentifier.quote(column.getColumn2(), needQuote) + " AS " +  QuoteIdentifier.quote(column.getColumn2() + "_" + index, needQuote);;
+                columnList[i] = tableAlias + "." + QuoteIdentifier.quote(column.getColumn2(), needQuote) + " AS " +  QuoteIdentifier.quote(column.getColumn2() + "_" + index, needQuote);
             }
         }
 
@@ -191,7 +191,7 @@ public class MetricParserUtils {
     }
 
     public static String getCoalesceString(String table, String column, boolean needQuote) {
-        return "coalesce(" + table + "." + QuoteIdentifier.quote(column, needQuote) + ", '')";
+        return String.format("COALESCE(CAST(%s.%s AS STRING), '')", table, QuoteIdentifier.quote(column, needQuote));
     }
 
     public static String getColumnIsNullStr(String table, List<String> columns, boolean needQuote) {


### PR DESCRIPTION
## Purpose of this pull request

During cross-table data validation, the current join condition COALESCE(table_a.column, '') = COALESCE(table_b.column, '') contains a logical issue that may lead to data type conversion errors when column types are inconsistent between tables. Specifically, this occurs in the following scenarios:

1. When table_a.column is NULL while table_b.column is non-NULL and of a non-string type
2. When both columns are non-NULL but have incompatible data types

The proposed solution is to standardize the comparison by explicitly casting both operands to strings:
COALESCE(CAST(table_a.column AS STRING), '') = COALESCE(CAST(table_b.column AS STRING), '')

## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] Change does not need document change
