### PR TITLE
[Fix][UI] Precision loss when displaying BigInt fields

### DIFF
--- a/datavines-server/src/main/java/io/datavines/server/config/JacksonConfig.java
+++ b/datavines-server/src/main/java/io/datavines/server/config/JacksonConfig.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.datavines.server.config;
+
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+@Configuration
+public class JacksonConfig {
+
+    /**
+     * Configure Jackson to serialize long, Long, BigInteger, BigDecimal as JSON strings
+     * to preserve precision for large numeric values in JavaScript frontends.
+     */
+    @Bean
+    public Jackson2ObjectMapperBuilderCustomizer jacksonLongToString() {
+        return builder -> {
+            // Serialize primitive long and Long wrapper as String
+            builder.serializerByType(Long.class, ToStringSerializer.instance);
+            builder.serializerByType(long.class, ToStringSerializer.instance);
+            // Also handle BigInteger and BigDecimal as String
+            builder.serializerByType(BigInteger.class, ToStringSerializer.instance);
+            builder.serializerByType(BigDecimal.class, ToStringSerializer.instance);
+        };
+    }
+} 


### PR DESCRIPTION
## Purpose of this pull request

When handling BIGINT values with large magnitudes (such as 19-20 digits), the frontend display incorrectly renders trailing digits as zeros, resulting in loss of numerical precision.

## Check list

* [ ] Code changed are covered with tests, or it does not need tests for reason:
* [ ] Change does not need document change
