### PR TITLE
[Fix][Security] Fix JWT authentication bypass via hardcoded secret and self-comparison logic

### DIFF
--- a/datavines-core/pom.xml
+++ b/datavines-core/pom.xml
@@ -149,6 +149,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jodd</groupId>
+            <artifactId>jodd-core</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/datavines-core/src/main/java/io/datavines/core/utils/TokenManager.java
+++ b/datavines-core/src/main/java/io/datavines/core/utils/TokenManager.java
@@ -19,6 +19,7 @@ package io.datavines.core.utils;
 import io.datavines.core.constant.DataVinesConstants;
 import io.datavines.core.exception.DataVinesServerException;
 import io.jsonwebtoken.CompressionCodecs;
+import jodd.util.BCrypt;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
@@ -35,11 +36,13 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.datavines.common.entity.TokenInfo;
 
+import javax.annotation.PostConstruct;
+
 @Slf4j
 @Component
 public class TokenManager {
 
-    @Value("${jwt.token.secret:asdqwe}")
+    @Value("${jwt.token.secret:}")
     private String tokenSecret;
 
     @Value("${jwt.token.timeout:8640000}")
@@ -47,6 +50,15 @@ public class TokenManager {
 
     @Value("${jwt.token.algorithm:HS256}")
     private String algorithm;
+
+    @PostConstruct
+    public void validateSecret() {
+        if (StringUtils.isEmpty(tokenSecret) || tokenSecret.length() < 16) {
+            log.warn("jwt.token.secret is not configured or too short, generating random secret");
+            tokenSecret = java.util.UUID.randomUUID().toString().replace("-", "")
+                        + java.util.UUID.randomUUID().toString().replace("-", "");
+        }
+    }
 
     public String generateToken(String username, String password) {
         Map<String, Object> claims = new HashMap<>();
@@ -163,7 +175,7 @@ public class TokenManager {
     public boolean validateToken(String token, String username, String password) {
         String tokenUsername = getUsername(token);
         String tokenPassword = getPassword(token);
-        return (username.equals(tokenUsername) && password.equals(tokenPassword) && !(isExpired(token)));
+        return (username.equals(tokenUsername) && BCrypt.checkpw(tokenPassword, password) && !(isExpired(token)));
     }
 
     private Date getCreatedDate(String token) {

--- a/datavines-core/src/main/java/io/datavines/core/utils/TokenManager.java
+++ b/datavines-core/src/main/java/io/datavines/core/utils/TokenManager.java
@@ -175,6 +175,9 @@ public class TokenManager {
     public boolean validateToken(String token, String username, String password) {
         String tokenUsername = getUsername(token);
         String tokenPassword = getPassword(token);
+        if (StringUtils.isEmpty(tokenUsername) || StringUtils.isEmpty(tokenPassword)) {
+            return false;
+        }
         return (username.equals(tokenUsername) && BCrypt.checkpw(tokenPassword, password) && !(isExpired(token)));
     }
 

--- a/datavines-server/src/main/java/io/datavines/server/api/inteceptor/AuthenticationInterceptor.java
+++ b/datavines-server/src/main/java/io/datavines/server/api/inteceptor/AuthenticationInterceptor.java
@@ -93,7 +93,7 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
         }
         request.setAttribute(DataVinesConstants.LOGIN_USER, user);
 
-        if (!tokeManager.validateToken(token, username, tokeManager.getPassword(token))) {
+        if (!tokeManager.validateToken(token, username, user.getPassword())) {
             throw new DataVinesServerException(Status.INVALID_TOKEN, token);
         }
 

--- a/datavines-server/src/main/resources/application.yaml
+++ b/datavines-server/src/main/resources/application.yaml
@@ -80,6 +80,12 @@ management:
 
 logging:
   config: classpath:server-logback.xml
+
+jwt:
+  token:
+    secret: PLEASE_CHANGE_THIS_TO_A_RANDOM_STRING
+    timeout: 8640000
+    algorithm: HS256
 ---
 spring:
   config:


### PR DESCRIPTION
### What is the purpose of the change

Fix a critical JWT authentication bypass vulnerability caused by two flaws:

1. **Hardcoded JWT secret**: `TokenManager` uses `@Value("${jwt.token.secret:asdqwe}")` with a hardcoded default, and `application.yaml` has no `jwt.token.secret` entry — all default deployments share the same secret.
2. **Self-comparison in token validation**: `AuthenticationInterceptor` passes `tokeManager.getPassword(token)` (extracted from the token itself) as the expected password to `validateToken`, which then compares it with itself — always returns true.

Combined, an attacker can forge a valid JWT for any user (e.g. `admin`) without knowing the actual password.

### Brief change log

- **`TokenManager.java`**: Remove hardcoded default secret `asdqwe`, add `@PostConstruct` startup validation to auto-generate a random secret if not configured, and change `validateToken` to use `BCrypt.checkpw` instead of `String.equals` for password comparison.
- **`AuthenticationInterceptor.java`**: Change `tokeManager.getPassword(token)` to `user.getPassword()` so the token's password is validated against the database BCrypt hash, not against itself.
- **`application.yaml`**: Add `jwt.token.secret` configuration entry so users can discover and configure a custom secret.

### Verify this change

- Forged tokens are now rejected (BCrypt check fails for fake passwords).
- Normal login and token refresh continue to work correctly.
- Tested locally with both forged and legitimate tokens.
